### PR TITLE
ECOM-2195 Mobile[iOS] - App Crashes When Scanner is Denied Camera Per…

### DIFF
--- a/android/ZBar.java
+++ b/android/ZBar.java
@@ -68,6 +68,9 @@ public class ZBar extends CordovaPlugin {
                 case ZBarScannerActivity.RESULT_ERROR:
                     scanCallbackContext.error("Scan failed due to an error");
                     break;
+                case ZBarScannerActivity.DENIED_CAMERA_PERMISSION_ERROR:
+                    scanCallbackContext.error("notHasPermission");
+                    break;
                 default:
                     scanCallbackContext.error("Unknown error");
             }

--- a/android/ZBarScannerActivity.java
+++ b/android/ZBarScannerActivity.java
@@ -58,6 +58,7 @@ implements SurfaceHolder.Callback {
     public static final String EXTRA_QRVALUE = "qrValue";
     public static final String EXTRA_PARAMS = "params";
     public static final int RESULT_ERROR = RESULT_FIRST_USER + 1;
+    public static final int DENIED_CAMERA_PERMISSION_ERROR = RESULT_FIRST_USER + 2;
     private static final int CAMERA_PERMISSION_REQUEST = 1;
     // State -----------------------------------------------------------
 
@@ -116,7 +117,9 @@ implements SurfaceHolder.Callback {
                     setUpCamera();
                 } else {
 
-                   onBackPressed();
+                   // onBackPressed();
+                    setResult(DENIED_CAMERA_PERMISSION_ERROR);
+                    super.onBackPressed();
                 }
                 return;
             }


### PR DESCRIPTION
…mission and User Tries Scanning Again after Existing Scanner

check permission on Android